### PR TITLE
Movement fix / minor minimap changes

### DIFF
--- a/lib/shard_web/live/user_live/movement.ex
+++ b/lib/shard_web/live/user_live/movement.ex
@@ -118,10 +118,10 @@ defmodule ShardWeb.UserLive.Movement do
       case key do
         # Align with DB: north increases y, south decreases y
         "ArrowUp" ->
-          {elem(curr_position, 0), elem(curr_position, 1) + 1}
+          {elem(curr_position, 0), elem(curr_position, 1) - 1}
 
         "ArrowDown" ->
-          {elem(curr_position, 0), elem(curr_position, 1) - 1}
+          {elem(curr_position, 0), elem(curr_position, 1) + 1}
 
         "ArrowRight" ->
           {elem(curr_position, 0) + 1, elem(curr_position, 1)}


### PR DESCRIPTION
conflicting changes to movement had been made.

Uninverted the minimaps y direction to match the current north south implimentations of doors.

north is up and a decreasing y value
south is down and a increasing y value

feel free to change but you will need to update the door generation and that was more effort then just rotating the map so the display match the current database.